### PR TITLE
Feat: Bump Astro Version & Dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "astro"
+      - dependency-name: "@astrojs/*"
+    groups:
+      astro-stack:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+    labels:
+      - "dependencies"
+      - "astro"
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@astrojs/vue": "^5.1.0",
                 "@tailwindcss/vite": "^4.1.11",
-                "astro": "^5.12.9",
+                "astro": "^5.13.4",
                 "tailwindcss": "^4.1.11",
                 "vue": "^3.5.18"
             },
@@ -74,9 +74,9 @@
             "license": "MIT"
         },
         "node_modules/@astrojs/internal-helpers": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.1.tgz",
-            "integrity": "sha512-7dwEVigz9vUWDw3nRwLQ/yH/xYovlUA0ZD86xoeKEBmkz9O6iELG1yri67PgAPW6VLL/xInA4t7H0CK6VmtkKQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.2.tgz",
+            "integrity": "sha512-KCkCqR3Goym79soqEtbtLzJfqhTWMyVaizUi35FLzgGSzBotSw8DB1qwsu7U96ihOJgYhDk2nVPz+3LnXPeX6g==",
             "license": "MIT"
         },
         "node_modules/@astrojs/language-server": {
@@ -122,12 +122,12 @@
             }
         },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.5.tgz",
-            "integrity": "sha512-MiR92CkE2BcyWf3b86cBBw/1dKiOH0qhLgXH2OXA6cScrrmmks1Rr4Tl0p/lFpvmgQQrP54Pd1uidJfmxGrpWQ==",
+            "version": "6.3.6",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.6.tgz",
+            "integrity": "sha512-bwylYktCTsLMVoCOEHbn2GSUA3c5KT/qilekBKA3CBng0bo1TYjNZPr761vxumRk9kJGqTOtU+fgCAp5Vwokug==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.7.1",
+                "@astrojs/internal-helpers": "0.7.2",
                 "@astrojs/prism": "3.3.0",
                 "github-slugger": "^2.0.0",
                 "hast-util-from-html": "^2.0.3",
@@ -2153,60 +2153,60 @@
             "license": "MIT"
         },
         "node_modules/@shikijs/core": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.9.2.tgz",
-            "integrity": "sha512-3q/mzmw09B2B6PgFNeiaN8pkNOixWS726IHmJEpjDAcneDPMQmUg2cweT9cWXY4XcyQS3i6mOOUgQz9RRUP6HA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.12.0.tgz",
+            "integrity": "sha512-rPfCBd6gHIKBPpf2hKKWn2ISPSrmRKAFi+bYDjvZHpzs3zlksWvEwaF3Z4jnvW+xHxSRef7qDooIJkY0RpA9EA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.9.2",
+                "@shikijs/types": "3.12.0",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.5"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.9.2.tgz",
-            "integrity": "sha512-kUTRVKPsB/28H5Ko6qEsyudBiWEDLst+Sfi+hwr59E0GLHV0h8RfgbQU7fdN5Lt9A8R1ulRiZyTvAizkROjwDA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.12.0.tgz",
+            "integrity": "sha512-Ni3nm4lnKxyKaDoXQQJYEayX052BL7D0ikU5laHp+ynxPpIF1WIwyhzrMU6WDN7AoAfggVR4Xqx3WN+JTS+BvA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.9.2",
+                "@shikijs/types": "3.12.0",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "oniguruma-to-es": "^4.3.3"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.9.2.tgz",
-            "integrity": "sha512-Vn/w5oyQ6TUgTVDIC/BrpXwIlfK6V6kGWDVVz2eRkF2v13YoENUvaNwxMsQU/t6oCuZKzqp9vqtEtEzKl9VegA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.12.0.tgz",
+            "integrity": "sha512-IfDl3oXPbJ/Jr2K8mLeQVpnF+FxjAc7ZPDkgr38uEw/Bg3u638neSrpwqOTnTHXt1aU0Fk1/J+/RBdst1kVqLg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.9.2",
+                "@shikijs/types": "3.12.0",
                 "@shikijs/vscode-textmate": "^10.0.2"
             }
         },
         "node_modules/@shikijs/langs": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.9.2.tgz",
-            "integrity": "sha512-X1Q6wRRQXY7HqAuX3I8WjMscjeGjqXCg/Sve7J2GWFORXkSrXud23UECqTBIdCSNKJioFtmUGJQNKtlMMZMn0w==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.12.0.tgz",
+            "integrity": "sha512-HIca0daEySJ8zuy9bdrtcBPhcYBo8wR1dyHk1vKrOuwDsITtZuQeGhEkcEfWc6IDyTcom7LRFCH6P7ljGSCEiQ==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.9.2"
+                "@shikijs/types": "3.12.0"
             }
         },
         "node_modules/@shikijs/themes": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.9.2.tgz",
-            "integrity": "sha512-6z5lBPBMRfLyyEsgf6uJDHPa6NAGVzFJqH4EAZ+03+7sedYir2yJBRu2uPZOKmj43GyhVHWHvyduLDAwJQfDjA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.12.0.tgz",
+            "integrity": "sha512-/lxvQxSI5s4qZLV/AuFaA4Wt61t/0Oka/P9Lmpr1UV+HydNCczO3DMHOC/CsXCCpbv4Zq8sMD0cDa7mvaVoj0Q==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.9.2"
+                "@shikijs/types": "3.12.0"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.9.2.tgz",
-            "integrity": "sha512-/M5L0Uc2ljyn2jKvj4Yiah7ow/W+DJSglVafvWAJ/b8AZDeeRAdMu3c2riDzB7N42VD+jSnWxeP9AKtd4TfYVw==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.12.0.tgz",
+            "integrity": "sha512-jsFzm8hCeTINC3OCmTZdhR9DOl/foJWplH2Px0bTi4m8z59fnsueLsweX82oGcjRQ7mfQAluQYKGoH2VzsWY4A==",
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
@@ -3299,14 +3299,14 @@
             }
         },
         "node_modules/astro": {
-            "version": "5.12.9",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.9.tgz",
-            "integrity": "sha512-cZ7kZ61jyE5nwSrFKSRyf5Gds+uJELqQxJFqMkcgiWQvhWZJUSShn8Uz3yc9WLyLw5Kim5P5un9SkJSGogfEZQ==",
+            "version": "5.13.4",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.13.4.tgz",
+            "integrity": "sha512-Mgq5GYy3EHtastGXqdnh1UPuN++8NmJSluAspA5hu33O7YRs/em/L03cUfRXtc60l5yx5BfYJsjF2MFMlcWlzw==",
             "license": "MIT",
             "dependencies": {
                 "@astrojs/compiler": "^2.12.2",
-                "@astrojs/internal-helpers": "0.7.1",
-                "@astrojs/markdown-remark": "6.3.5",
+                "@astrojs/internal-helpers": "0.7.2",
+                "@astrojs/markdown-remark": "6.3.6",
                 "@astrojs/telemetry": "3.3.0",
                 "@capsizecss/unpack": "^2.4.0",
                 "@oslojs/encoding": "^1.1.0",
@@ -8065,17 +8065,17 @@
             }
         },
         "node_modules/shiki": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.9.2.tgz",
-            "integrity": "sha512-t6NKl5e/zGTvw/IyftLcumolgOczhuroqwXngDeMqJ3h3EQiTY/7wmfgPlsmloD8oYfqkEDqxiaH37Pjm1zUhQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.12.0.tgz",
+            "integrity": "sha512-E+ke51tciraTHpaXYXfqnPZFSViKHhSQ3fiugThlfs/om/EonlQ0hSldcqgzOWWqX6PcjkKKzFgrjIaiPAXoaA==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "3.9.2",
-                "@shikijs/engine-javascript": "3.9.2",
-                "@shikijs/engine-oniguruma": "3.9.2",
-                "@shikijs/langs": "3.9.2",
-                "@shikijs/themes": "3.9.2",
-                "@shikijs/types": "3.9.2",
+                "@shikijs/core": "3.12.0",
+                "@shikijs/engine-javascript": "3.12.0",
+                "@shikijs/engine-oniguruma": "3.12.0",
+                "@shikijs/langs": "3.12.0",
+                "@shikijs/themes": "3.12.0",
+                "@shikijs/types": "3.12.0",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.4"
             }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@astrojs/vue": "^5.1.0",
         "@tailwindcss/vite": "^4.1.11",
-        "astro": "^5.12.9",
+        "astro": "^5.13.4",
         "tailwindcss": "^4.1.11",
         "vue": "^3.5.18"
     },


### PR DESCRIPTION
This pr covers issue #17 

It also adds a new feature with dependabot, where everytime a new astro version comes out it opens a pr.
I'm not sure if there are costs associated with using the dependabot daily; but given that until now, two astro versions
come out per month, maybe changing the value to `monthly` may be the best.

Here are the [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval) if anyone wants to do a bit more of reading on this matter.