### PR TITLE
fix: hydration

### DIFF
--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -6,6 +6,7 @@ import SheetDescription from '@/components/ui/sheet/SheetDescription.vue'
 import SheetHeader from '@/components/ui/sheet/SheetHeader.vue'
 import SheetTitle from '@/components/ui/sheet/SheetTitle.vue'
 import { SIDEBAR_WIDTH_MOBILE, useSidebar } from "./utils"
+import { ref, onMounted } from "vue"
 
 defineOptions({
   inheritAttrs: false,
@@ -15,6 +16,12 @@ const props = withDefaults(defineProps<SidebarProps>(), {
   side: "left",
   variant: "sidebar",
   collapsible: "offcanvas",
+})
+
+const mounted = ref(false)
+
+onMounted(() => {
+  mounted.value = true
 })
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
@@ -30,7 +37,7 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
     <slot />
   </div>
 
-  <Sheet v-else-if="isMobile" :open="openMobile" v-bind="$attrs" @update:open="setOpenMobile">
+  <Sheet v-else-if="mounted && isMobile" :open="openMobile" v-bind="$attrs" @update:open="setOpenMobile">
     <SheetContent
       data-sidebar="sidebar"
       data-slot="sidebar"


### PR DESCRIPTION
This PR fixes the hydration error caused by mismatched HTML between server and client:

<img width="544" height="273" alt="image" src="https://github.com/user-attachments/assets/b5d5164b-c176-4926-a46e-1ed79fafca7e" />

To solve this, I moved the sidebar rendering logic to run after the `mounted` lifecycle event. This ensures the initial server-rendered HTML matches the client, preventing hydration mismatches, while still leveraging Astro's update model. 😄